### PR TITLE
Fixed projectiles to prevent slowing down of game

### DIFF
--- a/client/src/components/gameplay/scripts/game/Hero.js
+++ b/client/src/components/gameplay/scripts/game/Hero.js
@@ -56,10 +56,12 @@ export class Hero {
 
   // creates the projectile and the direction
   fire(x, container, y) {
-    let projectile = new Projectile(x + 30, y + 40);
-    this.projectiles.push(projectile);
-    container.addChild(projectile.sprite);
-    this.container = container;
+    if (this.projectiles.length < 1) {
+      let projectile = new Projectile(x + 30, y + 40);
+      this.projectiles.push(projectile);
+      container.addChild(projectile.sprite);
+      this.container = container;
+    }
   }
 
   updateProjectiles() {


### PR DESCRIPTION
If there is a projectile, don't add another projectile until the first is destroyed.  Helps a lot with the slowing down of the game.  